### PR TITLE
Update site links to new domain

### DIFF
--- a/404.html
+++ b/404.html
@@ -8,8 +8,8 @@
     <meta name="author" content="Andres99">
     <meta property="og:title" content="404 Not Found - IPA Encryption Checker">
     <meta property="og:description" content="The page you are looking for could not be found">
-    <meta property="og:image" content="https://andres9890.github.io/ipa-encryption-checker/icon/IPA_icon.png">
-    <meta property="og:url" content="https://andres9890.github.io/ipa-encryption-checker/404">
+    <meta property="og:image" content="https://ipachecker.qzz.io/icon/IPA_icon.png">
+    <meta property="og:url" content="https://ipachecker.qzz.io/404">
     <meta name="twitter:card" content="summary_large_image">
     <title>404 Not Found - IPA Encryption Checker</title>
     <link rel="icon" href="icon/IPA_icon.png" type="image/png">
@@ -24,7 +24,7 @@
                 <i class="fas fa-moon dark-icon"></i>
             </div>
         </div>
-        <a href="https://andres9890.github.io/ipa-encryption-checker/" style="text-decoration: none; color: inherit;"><h1>IPA Encryption Checker</h1></a>
+        <a href="https://ipachecker.qzz.io/" style="text-decoration: none; color: inherit;"><h1>IPA Encryption Checker</h1></a>
         <p>404 - Page Not Found</p>
     </header>
     <main>
@@ -37,7 +37,7 @@
                 <li>Use the links below</li>
             </ul>
             <div class="return-link">
-                <a href="https://andres9890.github.io/ipa-encryption-checker" class="btn"><i class="fas fa-arrow-left"></i> Return to Home</a>
+                <a href="https://ipachecker.qzz.io" class="btn"><i class="fas fa-arrow-left"></i> Return to Home</a>
             </div>
         </div>
     </main>

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 [Terms of Service Button]: https://img.shields.io/badge/Terms_of_Service-red
-[Terms of Service Link]: https://andres9890.github.io/ipa-encryption-checker/routes/terms 'Terms of Service.'
+[Terms of Service Link]: https://ipachecker.qzz.io/routes/terms 'Terms of Service.'
 
 [Privacy Policy Button]: https://img.shields.io/badge/Privacy_Policy-red
-[Privacy Policy Link]: https://andres9890.github.io/ipa-encryption-checker/routes/privacy 'Privacy Policy.'
+[Privacy Policy Link]: https://ipachecker.qzz.io/routes/privacy 'Privacy Policy.'
 
 [Script Button]: https://img.shields.io/badge/Python_Script-green
-[Script Link]: https://andres9890.github.io/ipa-encryption-checker/routes/script 'Python Script.'
+[Script Link]: https://ipachecker.qzz.io/routes/script 'Python Script.'
 
 [License Button]: https://img.shields.io/badge/License-MIT-blue
 [License Link]: https://github.com/Andres9890/ipa-encryption-checker/blob/main/LICENSE 'MIT License.'
@@ -14,7 +14,7 @@
 [Vulnerabilities Link]: https://github.com/Andres9890/ipa-encryption-checker/blob/main/VULNERABILITIES.md 'Vulnerabilities.'
 
 
-# [IPA Encryption Checker](https://andres9890.github.io/ipa-encryption-checker/) (IEC)
+# [IPA Encryption Checker](https://ipachecker.qzz.io/) (IEC)
 [![License Button]][License Link]
 [![Vulnerabilities Button]][Vulnerabilities Link]
 [![Script Button]][Script Link]

--- a/index.html
+++ b/index.html
@@ -8,8 +8,8 @@
     <meta name="author" content="Andres99">
     <meta property="og:title" content="IPA Encryption Checker">
     <meta property="og:description" content="A website that checks if an IPA file is encrypted via a python script">
-    <meta property="og:image" content="https://andres9890.github.io/ipa-encryption-checker/icon/IPA_icon.png">
-    <meta property="og:url" content="https://andres9890.github.io/ipa-encryption-checker/">
+    <meta property="og:image" content="https://ipachecker.qzz.io/icon/IPA_icon.png">
+    <meta property="og:url" content="https://ipachecker.qzz.io/">
     <meta name="twitter:card" content="summary_large_image">
     <title>IPA Encryption Checker</title>
     <link rel="icon" href="icon/IPA_icon.png" type="image/png">
@@ -24,7 +24,7 @@
                 <i class="fas fa-moon dark-icon"></i>
             </div>
         </div>
-        <a href="https://andres9890.github.io/ipa-encryption-checker/" style="text-decoration: none; color: inherit;"><h1>IPA Encryption Checker</h1></a>
+        <a href="https://ipachecker.qzz.io/" style="text-decoration: none; color: inherit;"><h1>IPA Encryption Checker</h1></a>
         <p>Check if your IPA file(s) are encrypted (100MB limit, 5 files per upload)</p>
     </header>
     

--- a/robots.txt
+++ b/robots.txt
@@ -1,5 +1,5 @@
 # If you have any questions about this, ask them on the Github repo
-# Sitemap: https://andres9890.github.io/ipa-encryption-checker/sitemap.xml
+# Sitemap: https://ipachecker.qzz.io/sitemap.xml
 
 User-agent: *
 Disallow: /Screenshots/

--- a/routes/declaration.html
+++ b/routes/declaration.html
@@ -8,8 +8,8 @@
     <meta name="author" content="Founding Fathers">
     <meta property="og:title" content="The Declaration of Independence">
     <meta property="og:description" content="The unanimous Declaration of the thirteen united States of America">
-    <meta property="og:image" content="https://andres9890.github.io/ipa-encryption-checker/icon/IPA_icon.png">
-    <meta property="og:url" content="https://andres9890.github.io/ipa-encryption-checker/routes/declaration">
+    <meta property="og:image" content="https://ipachecker.qzz.io/icon/IPA_icon.png">
+    <meta property="og:url" content="https://ipachecker.qzz.io/routes/declaration">
     <meta name="twitter:card" content="summary_large_image">
     <title>The Declaration of Independence</title>
     <link rel="icon" href="../icon/IPA_icon.png" type="image/png">
@@ -101,7 +101,7 @@
             <div class="effective-date">Signed on: July 4, 1776</div>
             
             <div class="return-link">
-                <a href="https://andres9890.github.io/ipa-encryption-checker" class="btn"><i class="fas fa-arrow-left"></i> Return to Home</a>
+                <a href="https://ipachecker.qzz.io" class="btn"><i class="fas fa-arrow-left"></i> Return to Home</a>
             </div>
         </div>
     </main>

--- a/routes/privacy.html
+++ b/routes/privacy.html
@@ -8,8 +8,8 @@
     <meta name="author" content="Andres99">
     <meta property="og:title" content="IPA Encryption Checker - Privacy Policy">
     <meta property="og:description" content="Privacy Policy for IPA Encryption Checker">
-    <meta property="og:image" content="https://andres9890.github.io/ipa-encryption-checker/icon/IPA_icon.png">
-    <meta property="og:url" content="https://andres9890.github.io/ipa-encryption-checker/routes/privacy">
+    <meta property="og:image" content="https://ipachecker.qzz.io/icon/IPA_icon.png">
+    <meta property="og:url" content="https://ipachecker.qzz.io/routes/privacy">
     <meta name="twitter:card" content="summary_large_image">
     <title>IPA Encryption Checker - Privacy Policy</title>
     <link rel="icon" href="../icon/IPA_icon.png" type="image/png">
@@ -24,14 +24,14 @@
                 <i class="fas fa-moon dark-icon"></i>
             </div>
         </div>
-        <a href="https://andres9890.github.io/ipa-encryption-checker/" style="text-decoration: none; color: inherit;"><h1>IPA Encryption Checker</h1></a>
+        <a href="https://ipachecker.qzz.io/" style="text-decoration: none; color: inherit;"><h1>IPA Encryption Checker</h1></a>
         <p>Privacy Policy</p>
     </header>
     
     <main>
         <div class="terms-container">
             <h2 id="introduction">1. Introduction</h2>
-            <p>At IPA Encryption Checker, we respect your privacy and are committed to protecting it. This Privacy Policy explains how we collect, use, and safeguard your information when you use our website located at <a href="https://andres9890.github.io/ipa-encryption-checker/" style="color: var(--primary-color); font-weight: 600;">https://andres9890.github.io/ipa-encryption-checker/</a> (the "Service").</p>
+            <p>At IPA Encryption Checker, we respect your privacy and are committed to protecting it. This Privacy Policy explains how we collect, use, and safeguard your information when you use our website located at <a href="https://ipachecker.qzz.io/" style="color: var(--primary-color); font-weight: 600;">https://ipachecker.qzz.io/</a> (the "Service").</p>
             <p>We use your data solely to provide and improve the Service. By using the Service, you agree to the collection and use of information in accordance with this policy.</p>
             
             <h2 id="information-collected">2. Information We Collect</h2>
@@ -123,7 +123,7 @@
             <div class="effective-date">Effective Date: June 17, 2025</div>
             
             <div class="return-link">
-                <a href="https://andres9890.github.io/ipa-encryption-checker" class="btn"><i class="fas fa-arrow-left"></i> Return to Home</a>
+                <a href="https://ipachecker.qzz.io" class="btn"><i class="fas fa-arrow-left"></i> Return to Home</a>
             </div>
         </div>
     </main>

--- a/routes/script.html
+++ b/routes/script.html
@@ -8,8 +8,8 @@
     <meta name="author" content="Andres99">
     <meta property="og:title" content="IPA Encryption Checker - Python Script">
     <meta property="og:description" content="Python script for IPA Encryption Checker">
-    <meta property="og:image" content="https://andres9890.github.io/ipa-encryption-checker/icon/IPA_icon.png">
-    <meta property="og:url" content="https://andres9890.github.io/ipa-encryption-checker/routes/script">
+    <meta property="og:image" content="https://ipachecker.qzz.io/icon/IPA_icon.png">
+    <meta property="og:url" content="https://ipachecker.qzz.io/routes/script">
     <meta name="twitter:card" content="summary_large_image">
     <title>IPA Encryption Checker - Python Script</title>
     <link rel="icon" href="../icon/IPA_icon.png" type="image/png">
@@ -199,7 +199,7 @@
                 <i class="fas fa-moon dark-icon"></i>
             </div>
         </div>
-        <a href="https://andres9890.github.io/ipa-encryption-checker/" style="text-decoration: none; color: inherit;"><h1>IPA Encryption Checker</h1></a>
+        <a href="https://ipachecker.qzz.io/" style="text-decoration: none; color: inherit;"><h1>IPA Encryption Checker</h1></a>
         <p>Python Script</p>
     </header>
     
@@ -418,7 +418,7 @@ if __name__ == "__main__":
             </ol>
             
             <div class="return-link">
-                <a href="https://andres9890.github.io/ipa-encryption-checker" class="btn"><i class="fas fa-arrow-left"></i> Return to Home</a>
+                <a href="https://ipachecker.qzz.io" class="btn"><i class="fas fa-arrow-left"></i> Return to Home</a>
             </div>
         </div>
     </main>

--- a/routes/terms.html
+++ b/routes/terms.html
@@ -8,8 +8,8 @@
     <meta name="author" content="Andres99">
     <meta property="og:title" content="IPA Encryption Checker - Terms of Service">
     <meta property="og:description" content="Terms of Service for IPA Encryption Checker">
-    <meta property="og:image" content="https://andres9890.github.io/ipa-encryption-checker/icon/IPA_icon.png">
-    <meta property="og:url" content="https://andres9890.github.io/ipa-encryption-checker/routes/terms">
+    <meta property="og:image" content="https://ipachecker.qzz.io/icon/IPA_icon.png">
+    <meta property="og:url" content="https://ipachecker.qzz.io/routes/terms">
     <meta name="twitter:card" content="summary_large_image">
     <title>IPA Encryption Checker - Terms of Service</title>
     <link rel="icon" href="../icon/IPA_icon.png" type="image/png">
@@ -24,14 +24,14 @@
                 <i class="fas fa-moon dark-icon"></i>
             </div>
         </div>
-        <a href="https://andres9890.github.io/ipa-encryption-checker/" style="text-decoration: none; color: inherit;"><h1>IPA Encryption Checker</h1></a>
+        <a href="https://ipachecker.qzz.io/" style="text-decoration: none; color: inherit;"><h1>IPA Encryption Checker</h1></a>
         <p>Terms of Service</p>
     </header>
     
     <main>
         <div class="terms-container">
             <h2 id="introduction">1. Introduction</h2>
-            <p>Welcome to IPA Encryption Checker. These Terms of Service govern your use of our website located at <a href="https://andres9890.github.io/ipa-encryption-checker/" style="color: var(--primary-color); font-weight: 600;">https://andres9890.github.io/ipa-encryption-checker/</a> (the "Service"). By accessing or using the Service, you agree to be bound by these Terms.</p>
+            <p>Welcome to IPA Encryption Checker. These Terms of Service govern your use of our website located at <a href="https://ipachecker.qzz.io/" style="color: var(--primary-color); font-weight: 600;">https://ipachecker.qzz.io/</a> (the "Service"). By accessing or using the Service, you agree to be bound by these Terms.</p>
             <p>Please read these Terms carefully before using our Service. If you disagree with any part of the terms, you may not access the Service.</p>
             
             <h2 id="definitions">2. Definitions</h2>
@@ -89,7 +89,7 @@
             <div class="effective-date">Effective Date: June 17, 2025</div>
             
             <div class="return-link">
-                <a href="https://andres9890.github.io/ipa-encryption-checker" class="btn"><i class="fas fa-arrow-left"></i> Return to Home</a>
+                <a href="https://ipachecker.qzz.io" class="btn"><i class="fas fa-arrow-left"></i> Return to Home</a>
             </div>
         </div>
     </main>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -8,22 +8,22 @@
 
 
 <url>
-  <loc>https://andres9890.github.io/ipa-encryption-checker/</loc>
+  <loc>https://ipachecker.qzz.io/</loc>
   <lastmod>2025-06-11T17:28:50+00:00</lastmod>
   <priority>1.00</priority>
 </url>
 <url>
-  <loc>https://andres9890.github.io/ipa-encryption-checker/routes/terms</loc>
+  <loc>https://ipachecker.qzz.io/routes/terms</loc>
   <lastmod>2025-06-11T17:28:50+00:00</lastmod>
   <priority>0.80</priority>
 </url>
 <url>
-  <loc>https://andres9890.github.io/ipa-encryption-checker/routes/privacy</loc>
+  <loc>https://ipachecker.qzz.io/routes/privacy</loc>
   <lastmod>2025-06-11T17:28:50+00:00</lastmod>
   <priority>0.80</priority>
 </url>
 <url>
-  <loc>https://andres9890.github.io/ipa-encryption-checker/routes/script</loc>
+  <loc>https://ipachecker.qzz.io/routes/script</loc>
   <lastmod>2025-06-11T17:28:50+00:00</lastmod>
   <priority>0.80</priority>
 </url>


### PR DESCRIPTION
## Summary
- replace references to andres9890.github.io/ipa-encryption-checker with ipachecker.qzz.io across the HTML pages
- refresh sitemap, robots.txt, and README URLs to use the new domain

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf5765bcb08329ac46232e5e3b590f